### PR TITLE
Fix: 전략 리스트 탐색 시 아이콘 순서가 고정되지 않는 문제

### DIFF
--- a/src/main/java/com/be3c/sysmetic/domain/member/controller/TokenController.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/controller/TokenController.java
@@ -77,6 +77,8 @@ public class TokenController {
                 .profileImage(profileImage)
                 .totalFollowerCount(member.getTotalFollow())
                 .totalStrategyCount(member.getTotalStrategyCount())
+                .receiveInfoConsent(Boolean.valueOf(member.getReceiveInfoConsent()))
+                .receiveMarketingConsent(Boolean.valueOf(member.getReceiveMarketingConsent()))
                 .build();
 
         // 회원 정보 반환

--- a/src/main/java/com/be3c/sysmetic/domain/member/dto/TokenApiResponseDto.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/dto/TokenApiResponseDto.java
@@ -18,5 +18,7 @@ public class TokenApiResponseDto {
     private String profileImage;
     private Integer totalFollowerCount;
     private Integer totalStrategyCount;
+    private Boolean receiveInfoConsent;
+    private Boolean receiveMarketingConsent;
 
 }

--- a/src/main/java/com/be3c/sysmetic/domain/strategy/repository/StrategyStockReferenceRepository.java
+++ b/src/main/java/com/be3c/sysmetic/domain/strategy/repository/StrategyStockReferenceRepository.java
@@ -38,6 +38,6 @@ public interface StrategyStockReferenceRepository extends JpaRepository<Strategy
     List<StrategyStockReference> findAllByStockIds(@Param("ids") List<Long> ids);
 
     // StockGetter에서 사용
-    @Query("SELECT s FROM StrategyStockReference s WHERE s.strategy.id = :strategyId")
+    @Query("SELECT s FROM StrategyStockReference s WHERE s.strategy.id = :strategyId ORDER BY s.stock.id")
     List<StrategyStockReference> findAllByStrategyId(@Param("strategyId") Long strategyId);
 }


### PR DESCRIPTION
# 🚀 Pull Request
- 종목 리스트 불러올 때, 종목의 id 순서로 정렬되도록 변경
- /v1/auth 실행 시 해당 멤버의 정보성 수신 동의 여부 / 마케팅 수신 동의 여부 전송

## #️⃣ 연관된 이슈

#1 

## 📋 작업 내용
- 종목 리스트 불러올 때, 종목의 id 순서로 정렬되도록 변경
- /v1/auth 실행 시 해당 멤버의 정보성 수신 동의 여부 / 마케팅 수신 동의 여부 전송
