### PR TITLE
fix: 공지사항, 문의에서 정렬, 검색 시 이전 다음 글 오류 수정

### DIFF
--- a/src/main/java/com/be3c/sysmetic/domain/member/controller/InquiryController.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/controller/InquiryController.java
@@ -3,7 +3,6 @@ package com.be3c.sysmetic.domain.member.controller;
 import com.be3c.sysmetic.domain.member.dto.*;
 import com.be3c.sysmetic.domain.member.entity.Inquiry;
 import com.be3c.sysmetic.domain.member.entity.InquiryStatus;
-import com.be3c.sysmetic.domain.member.exception.MemberBadRequestException;
 import com.be3c.sysmetic.domain.member.service.InquiryAnswerService;
 import com.be3c.sysmetic.domain.member.service.InquiryService;
 import com.be3c.sysmetic.domain.strategy.entity.Strategy;
@@ -69,10 +68,11 @@ public class InquiryController implements InquiryControllerDocs {
                     .body(APIResponse.fail(ErrorCode.BAD_REQUEST, "쿼리 파라미터 searchType이 올바르지 않습니다."));
         }
 
-        InquiryAdminListShowRequestDto inquiryAdminListShowRequestDto = new InquiryAdminListShowRequestDto();
-        inquiryAdminListShowRequestDto.setTab(inquiryStatus);
-        inquiryAdminListShowRequestDto.setSearchType(searchType);
-        inquiryAdminListShowRequestDto.setSearchText(searchText);
+        InquiryAdminListShowRequestDto inquiryAdminListShowRequestDto = InquiryAdminListShowRequestDto.builder()
+                .closed(inquiryStatus)
+                .searchType(searchType)
+                .searchText(searchText)
+                .build();
 
         Page<Inquiry> inquiryList = inquiryService.findInquiriesAdmin(inquiryAdminListShowRequestDto, page);
 
@@ -103,11 +103,22 @@ public class InquiryController implements InquiryControllerDocs {
 //    @PreAuthorize("hasRole('ROLE_USER_MANAGER') or hasRole('ROLE_TRADER_MANAGER') or hasRole('ROLE_ADMIN')")
     @GetMapping("/admin/qna/{qnaId}")
     public ResponseEntity<APIResponse<InquiryAnswerAdminShowResponseDto>> showAdminInquiryDetail (
-            @PathVariable(value = "qnaId") Long inquiryId) {
+            @PathVariable(value = "qnaId") Long inquiryId,
+            @RequestParam(value = "closed", required = false, defaultValue = "all") String closed,
+            @RequestParam(value = "searchType", required = false, defaultValue = "strategy") String searchType,
+            @RequestParam(value = "searchText", required = false) String searchText) {
+        InquiryStatus inquiryStatus = InquiryStatus.valueOf(closed);
 
         try {
 
-            InquiryAnswerAdminShowResponseDto inquiryAnswerAdminShowResponseDto = inquiryService.inquiryIdToInquiryAnswerAdminShowResponseDto(inquiryId);
+            InquiryDetailAdminShowDto inquiryDetailAdminShowDto = InquiryDetailAdminShowDto.builder()
+                    .inquiryId(inquiryId)
+                    .closed(inquiryStatus)
+                    .searchType(searchType)
+                    .searchText(searchText)
+                    .build();
+
+            InquiryAnswerAdminShowResponseDto inquiryAnswerAdminShowResponseDto = inquiryService.inquiryIdToInquiryAnswerAdminShowResponseDto(inquiryDetailAdminShowDto);
 
             return ResponseEntity.status(HttpStatus.OK)
                     .body(APIResponse.success(inquiryAnswerAdminShowResponseDto));
@@ -298,11 +309,20 @@ public class InquiryController implements InquiryControllerDocs {
 //     @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_USER_MANAGER")
      @GetMapping("/member/qna/{qnaId}")
     public ResponseEntity<APIResponse<InquiryAnswerInquirerShowResponseDto>> showInquirerInquiryDetail (
-            @PathVariable(value = "qnaId") Long inquiryId) {
+            @PathVariable(value = "qnaId") Long inquiryId,
+            @RequestParam(value = "sort", defaultValue = "registrationDate") String sort,
+            @RequestParam(value = "closed", defaultValue = "all") String closed) {
+         InquiryStatus inquiryStatus = InquiryStatus.valueOf(closed);
 
          try {
 
-             InquiryAnswerInquirerShowResponseDto inquiryAnswerInquirerShowResponseDto = inquiryService.inquiryIdToInquiryAnswerInquirerShowResponseDto(inquiryId);
+             InquiryDetailTraderInquirerShowDto inquiryDetailTraderInquirerShowDto = InquiryDetailTraderInquirerShowDto.builder()
+                     .inquiryId(inquiryId)
+                     .closed(inquiryStatus)
+                     .sort(sort)
+                     .build();
+
+             InquiryAnswerInquirerShowResponseDto inquiryAnswerInquirerShowResponseDto = inquiryService.inquiryIdToInquiryAnswerInquirerShowResponseDto(inquiryDetailTraderInquirerShowDto);
 
              return ResponseEntity.status(HttpStatus.OK)
                      .body(APIResponse.success(inquiryAnswerInquirerShowResponseDto));
@@ -523,11 +543,20 @@ public class InquiryController implements InquiryControllerDocs {
 //    @PreAuthorize("hasRole('ROLE_TRADER') or hasRole('ROLE_TRADER_MANAGER')")
     @GetMapping("/trader/qna/{qnaId}")
     public ResponseEntity<APIResponse<InquiryAnswerTraderShowResponseDto>> showTraderInquiryDetail (
-            @PathVariable(value = "qnaId") Long inquiryId) {
+            @PathVariable(value = "qnaId") Long inquiryId,
+            @RequestParam(value = "sort", defaultValue = "registrationDate") String sort,
+            @RequestParam(value = "closed", defaultValue = "all") String closed) {
+        InquiryStatus inquiryStatus = InquiryStatus.valueOf(closed);
 
         try {
 
-            InquiryAnswerTraderShowResponseDto inquiryAnswerTraderShowResponseDto = inquiryService.inquiryIdToInquiryAnswerTraderShowResponseDto(inquiryId);
+            InquiryDetailTraderInquirerShowDto inquiryDetailTraderInquirerShowDto = InquiryDetailTraderInquirerShowDto.builder()
+                    .inquiryId(inquiryId)
+                    .sort(sort)
+                    .closed(inquiryStatus)
+                    .build();
+
+            InquiryAnswerTraderShowResponseDto inquiryAnswerTraderShowResponseDto = inquiryService.inquiryIdToInquiryAnswerTraderShowResponseDto(inquiryDetailTraderInquirerShowDto);
 
             return ResponseEntity.status(HttpStatus.OK)
                     .body(APIResponse.success(inquiryAnswerTraderShowResponseDto));

--- a/src/main/java/com/be3c/sysmetic/domain/member/controller/InquiryControllerDocs.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/controller/InquiryControllerDocs.java
@@ -79,8 +79,15 @@ public interface InquiryControllerDocs {
                     content = @Content(schema = @Schema(implementation = APIResponse.class))
             )
     })
+    @Parameters({
+            @Parameter(name = "closed", description = "답변 상태 탭 (사용: all, closed, unclosed) (설명: 전체, 답변완료, 답변대기)"),
+            @Parameter(name = "searchType", description = "검색 유형 (사용: strategy, trader, inquirer) (설명: 전략명, 트레이더, 질문자)")
+    })
     ResponseEntity<APIResponse<InquiryAnswerAdminShowResponseDto>> showAdminInquiryDetail (
-            @PathVariable(value = "qnaId") Long inquiryId);
+            @PathVariable(value = "qnaId") Long inquiryId,
+            @RequestParam(value = "closed", required = false, defaultValue = "all") String closed,
+            @RequestParam(value = "searchType", required = false, defaultValue = "strategy") String searchType,
+            @RequestParam(value = "searchText", required = false) String searchText);
 
 
     // 관리자 문의 삭제 API
@@ -259,8 +266,14 @@ public interface InquiryControllerDocs {
                     content = @Content(schema = @Schema(implementation = APIResponse.class))
             )
     })
+    @Parameters({
+            @Parameter(name = "sort", description = "정렬 순서 (사용: registrationDate, strategyName) (설명: '최신순', '전략명')"),
+            @Parameter(name = "closed", description = "답변 상태 탭 (사용: all, closed, unclosed) (설명: 전체, 답변완료, 답변대기)")
+    })
     ResponseEntity<APIResponse<InquiryAnswerInquirerShowResponseDto>> showInquirerInquiryDetail (
-            @PathVariable(value = "qnaId") Long inquiryId);
+            @PathVariable(value = "qnaId") Long inquiryId,
+            @RequestParam(value = "sort", defaultValue = "registrationDate") String sort,
+            @RequestParam(value = "closed", defaultValue = "all") String closed);
 
 
     // 질문자 문의 수정 화면 조회 API
@@ -445,6 +458,12 @@ public interface InquiryControllerDocs {
                     content = @Content(schema = @Schema(implementation = APIResponse.class))
             )
     })
+    @Parameters({
+            @Parameter(name = "sort", description = "정렬 순서 (사용: registrationDate, strategyName) (설명: '최신순', '전략명')"),
+            @Parameter(name = "closed", description = "답변 상태 탭 (사용: all, closed, unclosed) (설명: 전체, 답변완료, 답변대기)")
+    })
     ResponseEntity<APIResponse<InquiryAnswerTraderShowResponseDto>> showTraderInquiryDetail (
-            @PathVariable(value = "qnaId") Long inquiryId);
+            @PathVariable(value = "qnaId") Long inquiryId,
+            @RequestParam(value = "sort", defaultValue = "registrationDate") String sort,
+            @RequestParam(value = "closed", defaultValue = "all") String closed);
 }

--- a/src/main/java/com/be3c/sysmetic/domain/member/controller/NoticeContoller.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/controller/NoticeContoller.java
@@ -132,7 +132,7 @@ public class NoticeContoller implements NoticeControllerDocs {
 
 
     /*
-        관리자 공지사항 목록 공개여부 수정 API
+        관리자 공지사항 공개여부 수정 API
         1. 사용자 인증 정보가 없음 : FORBIDDEN
         2. 공개여부 수정에 성공했을 때 : OK
         3. 공개여부 수정에 실패했을 때 : INTERNAL_SERVER_ERROR
@@ -171,11 +171,13 @@ public class NoticeContoller implements NoticeControllerDocs {
 //    @PreAuthorize("hasRole('ROLE_USER_MANAGER') or hasRole('ROLE_TRADER_MANAGER') or hasRole('ROLE_ADMIN')")
     @GetMapping("/admin/notice/{noticeId}")
     public ResponseEntity<APIResponse<NoticeDetailAdminShowResponseDto>> showAdminNoticeDetail(
-            @PathVariable(name="noticeId") Long noticeId) {
+            @PathVariable(name="noticeId") Long noticeId,
+            @RequestParam(value = "searchType", required = false, defaultValue = "title") String searchType,
+            @RequestParam(value = "searchText", required = false) String searchText) {
 
         try {
 
-            NoticeDetailAdminShowResponseDto noticeDetailAdminShowResponseDto = noticeService.noticeIdToNoticeDetailAdminShowResponseDto(noticeId);
+            NoticeDetailAdminShowResponseDto noticeDetailAdminShowResponseDto = noticeService.noticeIdToNoticeDetailAdminShowResponseDto(noticeId, searchType, searchText);
 
             return ResponseEntity.status(HttpStatus.OK)
                     .body(APIResponse.success(noticeDetailAdminShowResponseDto));
@@ -393,12 +395,13 @@ public class NoticeContoller implements NoticeControllerDocs {
     @Override
     @GetMapping("/notice/{noticeId}")
     public ResponseEntity<APIResponse<NoticeDetailShowResponseDto>> showNoticeDetail(
-            @PathVariable(name="noticeId") Long noticeId) {
+            @PathVariable(name="noticeId") Long noticeId,
+            @RequestParam(value = "searchText", required = false) String searchText) {
 
         try {
             noticeService.upHits(noticeId);
 
-            NoticeDetailShowResponseDto noticeDetailShowResponseDto = noticeService.noticeIdToticeDetailShowResponseDto(noticeId);
+            NoticeDetailShowResponseDto noticeDetailShowResponseDto = noticeService.noticeIdToticeDetailShowResponseDto(noticeId, searchText);
 
             return ResponseEntity.status(HttpStatus.OK)
                     .body(APIResponse.success(noticeDetailShowResponseDto));

--- a/src/main/java/com/be3c/sysmetic/domain/member/controller/NoticeControllerDocs.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/controller/NoticeControllerDocs.java
@@ -87,10 +87,10 @@ public interface NoticeControllerDocs {
             @RequestParam(value = "searchText", required = false) String searchText);
 
 
-    // 관리자 공지사항 목록 공개여부 수정 API
+    // 관리자 공지사항 공개여부 수정 API
     @Operation(
-            summary = "관리자 공지사항 목록에서 개별 공개여부 수정",
-            description = "관리자가 공지사항 목록에서 개별 공지사항의 공개여부를 수정하는 API"
+            summary = "관리자 공지사항 개별 공개여부 수정",
+            description = "관리자가 개별 공지사항의 공개여부를 수정하는 API"
     )
     @ApiResponses({
             @ApiResponse(
@@ -140,8 +140,14 @@ public interface NoticeControllerDocs {
                     content = @Content(schema = @Schema(implementation = APIResponse.class))
             )
     })
+    @Parameters({
+            @Parameter(name = "searchType", description = "검색 유형 (사용: title, content, titlecontent, writer) (설명: 제목, 내용, 제목+내용, 작성자)"),
+            @Parameter(name = "searchText", description = "검색 텍스트")
+    })
     ResponseEntity<APIResponse<NoticeDetailAdminShowResponseDto>> showAdminNoticeDetail(
-            @PathVariable(name="noticeId") Long noticeId);
+            @PathVariable(name="noticeId") Long noticeId,
+            @RequestParam(value = "searchType", required = false, defaultValue = "title") String searchType,
+            @RequestParam(value = "searchText", required = false) String searchText);
 
 
     // 관리자 공지사항 수정 화면 조회 API
@@ -314,6 +320,10 @@ public interface NoticeControllerDocs {
                     content = @Content(schema = @Schema(implementation = APIResponse.class))
             )
     })
+    @Parameters({
+            @Parameter(name = "searchText", description = "검색 텍스트")
+    })
     ResponseEntity<APIResponse<NoticeDetailShowResponseDto>> showNoticeDetail(
-            @PathVariable(name="noticeId") Long noticeId);
+            @PathVariable(name="noticeId") Long noticeId,
+            @RequestParam(value = "searchText", required = false) String searchText);
 }

--- a/src/main/java/com/be3c/sysmetic/domain/member/dto/InquiryAnswerAdminShowResponseDto.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/dto/InquiryAnswerAdminShowResponseDto.java
@@ -16,6 +16,15 @@ import java.time.LocalDateTime;
 @Schema(description = "관리자 문의 답변 조회 응답 DTO")
 public class InquiryAnswerAdminShowResponseDto {
 
+    @Schema(description = "지정했던 답변상태", example = "searchType")
+    private String closed;
+
+    @Schema(description = "검색했던 검색 조건", example = "searchType")
+    private String searchType;
+
+    @Schema(description = "검색했던 검색 단어", example = "searchText")
+    private String searchText;
+
     @Schema(description = "문의 ID", example = "12345")
     private Long inquiryId;
 

--- a/src/main/java/com/be3c/sysmetic/domain/member/dto/InquiryAnswerInquirerShowResponseDto.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/dto/InquiryAnswerInquirerShowResponseDto.java
@@ -16,6 +16,12 @@ import java.time.LocalDateTime;
 @Schema(description = "관리자 문의 답변 조회 응답 DTO")
 public class InquiryAnswerInquirerShowResponseDto {
 
+    @Schema(description = "답변 상태 탭 (all, closed, unclosed) (전체, 답변완료, 답변대기)", example = "ALL")
+    private InquiryStatus closed; // ALL, CLOSED, UNCLOSED
+
+    @Schema(description = "정렬 순서 (registrationDate, strategyName) ('최신순', '전략명')", example = "최신순")
+    private String sort;
+
     @Schema(description = "문의 ID", example = "12345")
     private Long inquiryId;
 

--- a/src/main/java/com/be3c/sysmetic/domain/member/dto/InquiryAnswerTraderShowResponseDto.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/dto/InquiryAnswerTraderShowResponseDto.java
@@ -16,6 +16,12 @@ import java.time.LocalDateTime;
 @Schema(description = "관리자 문의 답변 조회 응답 DTO")
 public class InquiryAnswerTraderShowResponseDto {
 
+    @Schema(description = "답변 상태 탭 (all, closed, unclosed) (전체, 답변완료, 답변대기)", example = "ALL")
+    private InquiryStatus closed; // ALL, CLOSED, UNCLOSED
+
+    @Schema(description = "정렬 순서 (registrationDate, strategyName) ('최신순', '전략명')", example = "최신순")
+    private String sort;
+
     @Schema(description = "문의 ID", example = "12345")
     private Long inquiryId;
 

--- a/src/main/java/com/be3c/sysmetic/domain/member/dto/InquiryDetailAdminShowDto.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/dto/InquiryDetailAdminShowDto.java
@@ -10,8 +10,11 @@ import lombok.*;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
-@Schema(description = "관리자 문의 목록 요청 DTO")
-public class InquiryAdminListShowRequestDto {
+@Schema(description = "관리자 상세 조회 쿼리 파라미터 DTO")
+public class InquiryDetailAdminShowDto {
+
+    @Schema(description = "지금 문의 ID", example = "123")
+    private Long inquiryId;
 
     @Schema(description = "답변 상태 탭 (all, closed, unclosed) (전체, 답변완료, 답변대기)", example = "ALL")
     private InquiryStatus closed; // ALL, CLOSED, UNCLOSED

--- a/src/main/java/com/be3c/sysmetic/domain/member/dto/InquiryDetailTraderInquirerShowDto.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/dto/InquiryDetailTraderInquirerShowDto.java
@@ -1,0 +1,30 @@
+package com.be3c.sysmetic.domain.member.dto;
+
+import com.be3c.sysmetic.domain.member.entity.InquiryStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Builder
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "트레이더, 질문자 상세 조회 쿼리 파라미터 DTO")
+public class InquiryDetailTraderInquirerShowDto {
+
+    @Schema(description = "지금 문의 ID", example = "123")
+    private Long inquiryId;
+
+    @Schema(description = "문의자 ID", example = "1001")
+    private Long inquirerId;
+
+    @Schema(description = "트레이더 ID", example = "9876")
+    private Long traderId;
+
+    @Schema(description = "답변 상태 탭 (all, closed, unclosed) (전체, 답변완료, 답변대기)", example = "ALL")
+    private InquiryStatus closed; // ALL, CLOSED, UNCLOSED
+
+    @Schema(description = "정렬 순서 (registrationDate, strategyName) ('최신순', '전략명')", example = "최신순")
+    private String sort;
+}

--- a/src/main/java/com/be3c/sysmetic/domain/member/dto/InquiryListShowRequestDto.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/dto/InquiryListShowRequestDto.java
@@ -18,11 +18,7 @@ public class InquiryListShowRequestDto {
     @Schema(description = "트레이더 ID", example = "9876")
     private Long traderId;
 
-    // 정렬 순 셀렉트 박스
-    @Schema(description = "정렬 순서 (registrationDate, strategyName) ('최신순', '전략명')", example = "최신순")
-    private String sort;
-
     // 답변상태 셀렉트 박스
     @Schema(description = "답변 상태 (all, closed, unclosed)", example = "ALL")
-    private InquiryStatus tab;
+    private InquiryStatus closed;
 }

--- a/src/main/java/com/be3c/sysmetic/domain/member/dto/NoticeDetailAdminShowResponseDto.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/dto/NoticeDetailAdminShowResponseDto.java
@@ -15,6 +15,12 @@ import java.util.List;
 @Schema(description = "관리자 공지사항 상세 조회 응답 DTO")
 public class NoticeDetailAdminShowResponseDto {
 
+    @Schema(description = "검색했던 검색 조건", example = "searchType")
+    private String searchType;
+
+    @Schema(description = "검색했던 검색 단어", example = "searchText")
+    private String searchText;
+
     @Schema(description = "공지사항 ID", example = "123")
     private Long noticeId;
 

--- a/src/main/java/com/be3c/sysmetic/domain/member/dto/NoticeDetailShowResponseDto.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/dto/NoticeDetailShowResponseDto.java
@@ -15,6 +15,9 @@ import java.util.List;
 @Schema(description = "공지사항 상세 조회 응답 DTO")
 public class NoticeDetailShowResponseDto {
 
+    @Schema(description = "검색했던 검색 단어", example = "searchText")
+    private String searchText;
+
     @Schema(description = "공지사항 ID", example = "123")
     private Long noticeId;
 

--- a/src/main/java/com/be3c/sysmetic/domain/member/repository/InquiryRepository.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/repository/InquiryRepository.java
@@ -32,29 +32,29 @@ public interface InquiryRepository extends JpaRepository<Inquiry, Long>, Inquiry
     @Query("delete Inquiry i where i.id in :idList")
     int bulkDelete(@Param("idList") List<Long> idList);
 
-    // 관리자 이전 문의 조회
-    @Query("select i from Inquiry i where i.id < :inquiryId order by i.id desc")
-    List<Inquiry> adminFindPreviousInquiry(@Param("inquiryId") Long inquiryId, Pageable pageable);
-
-    // 관리자 다음 문의 조회
-    @Query("select i from Inquiry i where i.id > :inquiryId order by i.id asc")
-    List<Inquiry> adminFindNextInquiry(@Param("inquiryId") Long inquiryId, Pageable pageable);
-
-    // 트레이더 이전 문의 조회
-    @Query("select i from Inquiry i where i.id < :inquiryId and i.traderId = :traderId order by i.id desc")
-    List<Inquiry> traderFindPreviousInquiry(@Param("inquiryId") Long inquiryId, @Param("traderId") Long traderId, Pageable pageable);
-
-    // 트레이더 다음 문의 조회
-    @Query("select i from Inquiry i where i.id > :inquiryId and i.traderId = :traderId order by i.id asc")
-    List<Inquiry> traderFindNextInquiry(@Param("inquiryId") Long inquiryId, @Param("traderId") Long traderId, Pageable pageable);
-
-    // 질문자 이전 문의 조회
-    @Query("select i from Inquiry i where i.id < :inquiryId and i.inquirer.id = :inquirerId order by i.id desc")
-    List<Inquiry> inquirerFindPreviousInquiry(@Param("inquiryId") Long inquiryId, @Param("inquirerId") Long inquirerId, Pageable pageable);
-
-    // 질문자 다음 문의 조회
-    @Query("select i from Inquiry i where i.id > :inquiryId and i.inquirer.id = :inquirerId order by i.id asc")
-    List<Inquiry> inquirerFindNextInquiry(@Param("inquiryId") Long inquiryId, @Param("inquirerId") Long inquirerId, Pageable pageable);
+//    // 관리자 이전 문의 조회
+//    @Query("select i from Inquiry i where i.id < :inquiryId order by i.id desc")
+//    List<Inquiry> adminFindPreviousInquiry(@Param("inquiryId") Long inquiryId, Pageable pageable);
+//
+//    // 관리자 다음 문의 조회
+//    @Query("select i from Inquiry i where i.id > :inquiryId order by i.id asc")
+//    List<Inquiry> adminFindNextInquiry(@Param("inquiryId") Long inquiryId, Pageable pageable);
+//
+//    // 트레이더 이전 문의 조회
+//    @Query("select i from Inquiry i where i.id < :inquiryId and i.traderId = :traderId order by i.id desc")
+//    List<Inquiry> traderFindPreviousInquiry(@Param("inquiryId") Long inquiryId, @Param("traderId") Long traderId, Pageable pageable);
+//
+//    // 트레이더 다음 문의 조회
+//    @Query("select i from Inquiry i where i.id > :inquiryId and i.traderId = :traderId order by i.id asc")
+//    List<Inquiry> traderFindNextInquiry(@Param("inquiryId") Long inquiryId, @Param("traderId") Long traderId, Pageable pageable);
+//
+//    // 질문자 이전 문의 조회
+//    @Query("select i from Inquiry i where i.id < :inquiryId and i.inquirer.id = :inquirerId order by i.id desc")
+//    List<Inquiry> inquirerFindPreviousInquiry(@Param("inquiryId") Long inquiryId, @Param("inquirerId") Long inquirerId, Pageable pageable);
+//
+//    // 질문자 다음 문의 조회
+//    @Query("select i from Inquiry i where i.id > :inquiryId and i.inquirer.id = :inquirerId order by i.id asc")
+//    List<Inquiry> inquirerFindNextInquiry(@Param("inquiryId") Long inquiryId, @Param("inquirerId") Long inquirerId, Pageable pageable);
 
     // 이전 문의 조회
     @Query("select i from Inquiry i where i.id < :inquiryId order by i.id desc")

--- a/src/main/java/com/be3c/sysmetic/domain/member/repository/InquiryRepository.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/repository/InquiryRepository.java
@@ -32,30 +32,6 @@ public interface InquiryRepository extends JpaRepository<Inquiry, Long>, Inquiry
     @Query("delete Inquiry i where i.id in :idList")
     int bulkDelete(@Param("idList") List<Long> idList);
 
-//    // 관리자 이전 문의 조회
-//    @Query("select i from Inquiry i where i.id < :inquiryId order by i.id desc")
-//    List<Inquiry> adminFindPreviousInquiry(@Param("inquiryId") Long inquiryId, Pageable pageable);
-//
-//    // 관리자 다음 문의 조회
-//    @Query("select i from Inquiry i where i.id > :inquiryId order by i.id asc")
-//    List<Inquiry> adminFindNextInquiry(@Param("inquiryId") Long inquiryId, Pageable pageable);
-//
-//    // 트레이더 이전 문의 조회
-//    @Query("select i from Inquiry i where i.id < :inquiryId and i.traderId = :traderId order by i.id desc")
-//    List<Inquiry> traderFindPreviousInquiry(@Param("inquiryId") Long inquiryId, @Param("traderId") Long traderId, Pageable pageable);
-//
-//    // 트레이더 다음 문의 조회
-//    @Query("select i from Inquiry i where i.id > :inquiryId and i.traderId = :traderId order by i.id asc")
-//    List<Inquiry> traderFindNextInquiry(@Param("inquiryId") Long inquiryId, @Param("traderId") Long traderId, Pageable pageable);
-//
-//    // 질문자 이전 문의 조회
-//    @Query("select i from Inquiry i where i.id < :inquiryId and i.inquirer.id = :inquirerId order by i.id desc")
-//    List<Inquiry> inquirerFindPreviousInquiry(@Param("inquiryId") Long inquiryId, @Param("inquirerId") Long inquirerId, Pageable pageable);
-//
-//    // 질문자 다음 문의 조회
-//    @Query("select i from Inquiry i where i.id > :inquiryId and i.inquirer.id = :inquirerId order by i.id asc")
-//    List<Inquiry> inquirerFindNextInquiry(@Param("inquiryId") Long inquiryId, @Param("inquirerId") Long inquirerId, Pageable pageable);
-
     // 이전 문의 조회
     @Query("select i from Inquiry i where i.id < :inquiryId order by i.id desc")
     List<Inquiry> findPreviousInquiry(@Param("inquiryId") Long inquiryId, Pageable pageable);

--- a/src/main/java/com/be3c/sysmetic/domain/member/repository/InquiryRepositoryCustom.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/repository/InquiryRepositoryCustom.java
@@ -1,12 +1,15 @@
 package com.be3c.sysmetic.domain.member.repository;
 
 import com.be3c.sysmetic.domain.member.dto.InquiryAdminListShowRequestDto;
+import com.be3c.sysmetic.domain.member.dto.InquiryDetailAdminShowDto;
+import com.be3c.sysmetic.domain.member.dto.InquiryDetailTraderInquirerShowDto;
 import com.be3c.sysmetic.domain.member.dto.InquiryListShowRequestDto;
 import com.be3c.sysmetic.domain.member.entity.Inquiry;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface InquiryRepositoryCustom {
 
@@ -14,5 +17,23 @@ public interface InquiryRepositoryCustom {
 
     Page<Inquiry> pageInquirySearchWithBooleanBuilder(InquiryListShowRequestDto inquiryListShowRequestDto, Pageable pageable);
 
-    List<Inquiry> listInquirySearchWithBooleanBuilder(InquiryListShowRequestDto inquiryListShowRequestDto);
+    List<Inquiry> listTraderInquirySearchWithBooleanBuilder(InquiryListShowRequestDto inquiryListShowRequestDto);
+
+    List<Inquiry> listInquirerInquirySearchWithBooleanBuilder(InquiryListShowRequestDto inquiryListShowRequestDto);
+
+    Optional<Inquiry> adminFindPreviousInquiry(InquiryDetailAdminShowDto inquiryDetailAdminShowDto);
+
+    Optional<Inquiry> adminFindNextInquiry(InquiryDetailAdminShowDto inquiryDetailAdminShowDto);
+
+    Optional<Inquiry> inquirerFindPreviousInquiryRegistrationDate(InquiryDetailTraderInquirerShowDto inquiryDetailTraderInquirerShowDto);
+    Optional<Inquiry> inquirerFindPreviousInquiryStrategyName(InquiryDetailTraderInquirerShowDto inquiryDetailTraderInquirerShowDto);
+
+    Optional<Inquiry> inquirerFindNextInquiryRegistrationDate(InquiryDetailTraderInquirerShowDto inquiryDetailTraderInquirerShowDto);
+    Optional<Inquiry> inquirerFindNextInquiryStrategyName(InquiryDetailTraderInquirerShowDto inquiryDetailTraderInquirerShowDto);
+
+    Optional<Inquiry> traderFindPreviousInquiryRegistrationDate(InquiryDetailTraderInquirerShowDto inquiryDetailTraderInquirerShowDto);
+    Optional<Inquiry> traderFindPreviousInquiryStrategyName(InquiryDetailTraderInquirerShowDto inquiryDetailTraderInquirerShowDto);
+
+    Optional<Inquiry> traderFindNextInquiryRegistrationDate(InquiryDetailTraderInquirerShowDto inquiryDetailTraderInquirerShowDto);
+    Optional<Inquiry> traderFindNextInquiryStrategyName(InquiryDetailTraderInquirerShowDto inquiryDetailTraderInquirerShowDto);
 }

--- a/src/main/java/com/be3c/sysmetic/domain/member/repository/InquiryRepositoryImpl.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/repository/InquiryRepositoryImpl.java
@@ -1,6 +1,8 @@
 package com.be3c.sysmetic.domain.member.repository;
 
 import com.be3c.sysmetic.domain.member.dto.InquiryAdminListShowRequestDto;
+import com.be3c.sysmetic.domain.member.dto.InquiryDetailAdminShowDto;
+import com.be3c.sysmetic.domain.member.dto.InquiryDetailTraderInquirerShowDto;
 import com.be3c.sysmetic.domain.member.dto.InquiryListShowRequestDto;
 import com.be3c.sysmetic.domain.member.entity.Inquiry;
 import com.be3c.sysmetic.domain.member.entity.InquiryStatus;
@@ -18,6 +20,7 @@ import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -26,29 +29,28 @@ public class InquiryRepositoryImpl implements InquiryRepositoryCustom {
     private final JPAQueryFactory jpaQueryFactory;
     private final JPAQueryFactory jpaQueryFactory1;
     private final JPAQueryFactory jpaQueryFactory2;
-    private final JPAQueryFactory jpaQueryFactory3;
     private final QInquiry inquiry = QInquiry.inquiry;
 
     public Page<Inquiry> adminInquirySearchWithBooleanBuilder(InquiryAdminListShowRequestDto inquiryAdminListShowRequestDto, Pageable pageable) {
 
         BooleanBuilder predicate = new BooleanBuilder();
 
-        InquiryStatus tab = inquiryAdminListShowRequestDto.getTab();
+        InquiryStatus closed = inquiryAdminListShowRequestDto.getClosed();
         String searchType = inquiryAdminListShowRequestDto.getSearchType();
         String searchText = inquiryAdminListShowRequestDto.getSearchText();
 
         // 전체, 답변 대기, 답변 완료
-        if (tab.equals(InquiryStatus.unclosed)) {
-            predicate.and(inquiry.inquiryStatus.eq(tab));
-        } else if (tab.equals(InquiryStatus.closed)) {
-            predicate.and(inquiry.inquiryStatus.eq(tab));
+        if (closed.equals(InquiryStatus.unclosed)) {
+            predicate.and(inquiry.inquiryStatus.eq(closed));
+        } else if (closed.equals(InquiryStatus.closed)) {
+            predicate.and(inquiry.inquiryStatus.eq(closed));
         }
 
         // 검색 (전략명, 트레이더, 질문자)
         if (StringUtils.hasText(searchText)) {
             if (searchType.equals("strategy")) {
                 predicate.and(inquiry.strategy.name.contains(searchText));
-                predicate.and(inquiry.strategy.statusCode.eq(StrategyStatusCode.PUBLIC.getCode()));
+                predicate.and(inquiry.strategy.statusCode.eq(StrategyStatusCode.NOT_USING_STATE.getCode()).not());
             } else if (searchType.equals("trader")) {
                 predicate.and(inquiry.strategy.trader.nickname.contains(searchText));
             } else if (searchType.equals("inquirer")) {
@@ -77,7 +79,7 @@ public class InquiryRepositoryImpl implements InquiryRepositoryCustom {
 
         Long inquirerId = inquiryListShowRequestDto.getInquirerId();
         Long traderId = inquiryListShowRequestDto.getTraderId();
-        InquiryStatus tab = inquiryListShowRequestDto.getTab();
+        InquiryStatus closed = inquiryListShowRequestDto.getClosed();
 
         // 질문자 별
         if (inquirerId != null) {
@@ -90,10 +92,10 @@ public class InquiryRepositoryImpl implements InquiryRepositoryCustom {
         }
 
         // 전체, 답변 대기, 답변 완료
-        if (tab.equals(InquiryStatus.unclosed)) {
-            predicate.and(inquiry.inquiryStatus.eq(tab));
-        } else if (tab.equals(InquiryStatus.closed)) {
-            predicate.and(inquiry.inquiryStatus.eq(tab));
+        if (closed.equals(InquiryStatus.unclosed)) {
+            predicate.and(inquiry.inquiryStatus.eq(closed));
+        } else if (closed.equals(InquiryStatus.closed)) {
+            predicate.and(inquiry.inquiryStatus.eq(closed));
         }
 
         List<Inquiry> content = new ArrayList<>();
@@ -113,14 +115,14 @@ public class InquiryRepositoryImpl implements InquiryRepositoryCustom {
         return new PageImpl<>(content, pageable, total);
     }
 
-    public List<Inquiry> listInquirySearchWithBooleanBuilder(InquiryListShowRequestDto inquiryListShowRequestDto) {
+    public List<Inquiry> listTraderInquirySearchWithBooleanBuilder(InquiryListShowRequestDto inquiryListShowRequestDto) {
 
         BooleanBuilder predicate1 = new BooleanBuilder();
         BooleanBuilder predicate2 = new BooleanBuilder();
 
         Long inquirerId = inquiryListShowRequestDto.getInquirerId();
         Long traderId = inquiryListShowRequestDto.getTraderId();
-        InquiryStatus tab = inquiryListShowRequestDto.getTab();
+        InquiryStatus closed = inquiryListShowRequestDto.getClosed();
 
         // 질문자 별
         if (inquirerId != null) {
@@ -135,12 +137,63 @@ public class InquiryRepositoryImpl implements InquiryRepositoryCustom {
         }
 
         // 전체, 답변 대기, 답변 완료
-        if (tab.equals(InquiryStatus.unclosed)) {
-            predicate1.and(inquiry.inquiryStatus.eq(tab));
-            predicate2.and(inquiry.inquiryStatus.eq(tab));
-        } else if (tab.equals(InquiryStatus.closed)) {
-            predicate1.and(inquiry.inquiryStatus.eq(tab));
-            predicate2.and(inquiry.inquiryStatus.eq(tab));
+        if (closed.equals(InquiryStatus.unclosed)) {
+            predicate1.and(inquiry.inquiryStatus.eq(closed));
+            predicate2.and(inquiry.inquiryStatus.eq(closed));
+        } else if (closed.equals(InquiryStatus.closed)) {
+            predicate1.and(inquiry.inquiryStatus.eq(closed));
+            predicate2.and(inquiry.inquiryStatus.eq(closed));
+        }
+
+        predicate1.and(inquiry.strategy.statusCode.eq(StrategyStatusCode.NOT_USING_STATE.getCode()).not());
+        predicate2.and(inquiry.strategy.statusCode.eq(StrategyStatusCode.NOT_USING_STATE.getCode()));
+
+        List<Inquiry> content = new ArrayList<>();
+        List<Inquiry> results1 = jpaQueryFactory1
+                .selectFrom(inquiry)
+                .where(predicate1)
+                .orderBy(inquiry.strategy.name.asc(), inquiry.id.desc()) // 따로 해서 최적화 가능
+                .fetch();
+        List<Inquiry> results2 = jpaQueryFactory2
+                .selectFrom(inquiry)
+                .where(predicate2)
+                .orderBy(inquiry.id.desc()) // 따로 해서 최적화 가능
+                .fetch();
+
+        content.addAll(results1);
+        content.addAll(results2);
+
+        return content;
+    }
+
+    public List<Inquiry> listInquirerInquirySearchWithBooleanBuilder(InquiryListShowRequestDto inquiryListShowRequestDto) {
+
+        BooleanBuilder predicate1 = new BooleanBuilder();
+        BooleanBuilder predicate2 = new BooleanBuilder();
+
+        Long inquirerId = inquiryListShowRequestDto.getInquirerId();
+        Long traderId = inquiryListShowRequestDto.getTraderId();
+        InquiryStatus closed = inquiryListShowRequestDto.getClosed();
+
+        // 질문자 별
+        if (inquirerId != null) {
+            predicate1.and(inquiry.inquirer.id.eq(inquirerId));
+            predicate2.and(inquiry.inquirer.id.eq(inquirerId));
+        }
+
+        // 트레이더 별
+        if (traderId != null) {
+            predicate1.and(inquiry.traderId.eq(traderId));
+            predicate2.and(inquiry.traderId.eq(traderId));
+        }
+
+        // 전체, 답변 대기, 답변 완료
+        if (closed.equals(InquiryStatus.unclosed)) {
+            predicate1.and(inquiry.inquiryStatus.eq(closed));
+            predicate2.and(inquiry.inquiryStatus.eq(closed));
+        } else if (closed.equals(InquiryStatus.closed)) {
+            predicate1.and(inquiry.inquiryStatus.eq(closed));
+            predicate2.and(inquiry.inquiryStatus.eq(closed));
         }
 
         predicate1.and(inquiry.strategy.statusCode.eq(StrategyStatusCode.PUBLIC.getCode()));
@@ -162,5 +215,585 @@ public class InquiryRepositoryImpl implements InquiryRepositoryCustom {
         content.addAll(results2);
 
         return content;
+    }
+
+    // 관리자 이전 문의 조회
+    public Optional<Inquiry> adminFindPreviousInquiry(InquiryDetailAdminShowDto inquiryDetailAdminShowDto) {
+
+        BooleanBuilder predicate = new BooleanBuilder();
+
+        Long inquiryId = inquiryDetailAdminShowDto.getInquiryId();
+        InquiryStatus closed = inquiryDetailAdminShowDto.getClosed();
+        String searchType = inquiryDetailAdminShowDto.getSearchType();
+        String searchText = inquiryDetailAdminShowDto.getSearchText();
+
+        // 전체, 답변 대기, 답변 완료
+        if (closed.equals(InquiryStatus.unclosed)) {
+            predicate.and(inquiry.inquiryStatus.eq(closed));
+        } else if (closed.equals(InquiryStatus.closed)) {
+            predicate.and(inquiry.inquiryStatus.eq(closed));
+        }
+
+        // 검색 (전략명, 트레이더, 질문자)
+        if (StringUtils.hasText(searchText)) {
+            if (searchType.equals("strategy")) {
+                predicate.and(inquiry.strategy.name.contains(searchText));
+                predicate.and(inquiry.strategy.statusCode.eq(StrategyStatusCode.NOT_USING_STATE.getCode()).not());
+            } else if (searchType.equals("trader")) {
+                predicate.and(inquiry.strategy.trader.nickname.contains(searchText));
+            } else if (searchType.equals("inquirer")) {
+                predicate.and(inquiry.inquirer.nickname.contains(searchText));
+            }
+        }
+
+        predicate.and(inquiry.id.lt(inquiryId));
+
+        return Optional.ofNullable(jpaQueryFactory
+                .selectFrom(inquiry)
+                .where(predicate)
+                .orderBy(inquiry.id.desc())
+                .fetchFirst());
+    }
+
+    // 관리자 다음 문의 조회
+    public Optional<Inquiry> adminFindNextInquiry(InquiryDetailAdminShowDto inquiryDetailAdminShowDto) {
+
+        BooleanBuilder predicate = new BooleanBuilder();
+
+        Long inquiryId = inquiryDetailAdminShowDto.getInquiryId();
+        InquiryStatus closed = inquiryDetailAdminShowDto.getClosed();
+        String searchType = inquiryDetailAdminShowDto.getSearchType();
+        String searchText = inquiryDetailAdminShowDto.getSearchText();
+
+        // 전체, 답변 대기, 답변 완료
+        if (closed.equals(InquiryStatus.unclosed)) {
+            predicate.and(inquiry.inquiryStatus.eq(closed));
+        } else if (closed.equals(InquiryStatus.closed)) {
+            predicate.and(inquiry.inquiryStatus.eq(closed));
+        }
+
+        // 검색 (전략명, 트레이더, 질문자)
+        if (StringUtils.hasText(searchText)) {
+            if (searchType.equals("strategy")) {
+                predicate.and(inquiry.strategy.name.contains(searchText));
+                predicate.and(inquiry.strategy.statusCode.eq(StrategyStatusCode.NOT_USING_STATE.getCode()).not());
+            } else if (searchType.equals("trader")) {
+                predicate.and(inquiry.strategy.trader.nickname.contains(searchText));
+            } else if (searchType.equals("inquirer")) {
+                predicate.and(inquiry.inquirer.nickname.contains(searchText));
+            }
+        }
+
+        predicate.and(inquiry.id.gt(inquiryId));
+
+        return Optional.ofNullable(jpaQueryFactory
+                .selectFrom(inquiry)
+                .where(predicate)
+                .orderBy(inquiry.id.asc())
+                .fetchFirst());
+    }
+
+    // 질문자 이전 문의 조회
+    public Optional<Inquiry> inquirerFindPreviousInquiry(InquiryDetailTraderInquirerShowDto inquiryDetailTraderInquirerShowDto) {
+
+        BooleanBuilder predicate = new BooleanBuilder();
+        BooleanBuilder predicate1 = new BooleanBuilder();
+        BooleanBuilder predicate2 = new BooleanBuilder();
+
+        Long inquiryId = inquiryDetailTraderInquirerShowDto.getInquiryId();
+        Long inquirerId = inquiryDetailTraderInquirerShowDto.getInquirerId();
+        InquiryStatus closed = inquiryDetailTraderInquirerShowDto.getClosed();
+        String sort = inquiryDetailTraderInquirerShowDto.getSort();
+
+        // 질문자 별
+        if (inquirerId != null) {
+            predicate.and(inquiry.inquirer.id.eq(inquirerId));
+            predicate1.and(inquiry.inquirer.id.eq(inquirerId));
+            predicate2.and(inquiry.inquirer.id.eq(inquirerId));
+        }
+
+        // 전체, 답변 대기, 답변 완료
+        if (closed.equals(InquiryStatus.unclosed)) {
+            predicate.and(inquiry.inquiryStatus.eq(closed));
+            predicate1.and(inquiry.inquiryStatus.eq(closed));
+            predicate2.and(inquiry.inquiryStatus.eq(closed));
+        } else if (closed.equals(InquiryStatus.closed)) {
+            predicate.and(inquiry.inquiryStatus.eq(closed));
+            predicate1.and(inquiry.inquiryStatus.eq(closed));
+            predicate2.and(inquiry.inquiryStatus.eq(closed));
+        }
+
+        predicate1.and(inquiry.strategy.statusCode.eq(StrategyStatusCode.PUBLIC.getCode()));
+        predicate2.and(inquiry.strategy.statusCode.eq(StrategyStatusCode.PUBLIC.getCode()).not());
+
+        predicate.and(inquiry.id.lt(inquiryId));
+
+        // 정렬순 별
+        if (sort.equals("registrationDate")) {
+            return Optional.ofNullable(jpaQueryFactory
+                    .selectFrom(inquiry)
+                    .where(predicate)
+                    .orderBy(inquiry.id.desc())
+                    .fetchFirst());
+        } else if (sort.equals("strategyName")) {
+
+            List<Inquiry> content = new ArrayList<>();
+            List<Inquiry> results1 = jpaQueryFactory1
+                    .selectFrom(inquiry)
+                    .where(predicate1)
+                    .orderBy(inquiry.strategy.name.asc(), inquiry.id.desc()) // 따로 해서 최적화 가능
+                    .fetch();
+            List<Inquiry> results2 = jpaQueryFactory2
+                    .selectFrom(inquiry)
+                    .where(predicate2)
+                    .orderBy(inquiry.id.desc()) // 따로 해서 최적화 가능
+                    .fetch();
+
+            content.addAll(results1);
+            content.addAll(results2);
+
+            if (content.isEmpty()) {
+                return Optional.empty();
+            } else {
+                return Optional.ofNullable(content.get(0));
+            }
+        } else {
+            throw new IllegalArgumentException("정렬순을 지정하세요");
+        }
+    }
+
+    // 질문자 다음 문의 조회
+    public Optional<Inquiry> inquirerFindNextInquiry(InquiryDetailTraderInquirerShowDto inquiryDetailTraderInquirerShowDto) {
+
+        BooleanBuilder predicate = new BooleanBuilder();
+        BooleanBuilder predicate1 = new BooleanBuilder();
+        BooleanBuilder predicate2 = new BooleanBuilder();
+
+        Long inquiryId = inquiryDetailTraderInquirerShowDto.getInquiryId();
+        Long inquirerId = inquiryDetailTraderInquirerShowDto.getInquirerId();
+        InquiryStatus closed = inquiryDetailTraderInquirerShowDto.getClosed();
+        String sort = inquiryDetailTraderInquirerShowDto.getSort();
+
+        // 질문자 별
+        if (inquirerId != null) {
+            predicate.and(inquiry.inquirer.id.eq(inquirerId));
+            predicate1.and(inquiry.inquirer.id.eq(inquirerId));
+            predicate2.and(inquiry.inquirer.id.eq(inquirerId));
+        }
+
+        // 전체, 답변 대기, 답변 완료
+        if (closed.equals(InquiryStatus.unclosed)) {
+            predicate.and(inquiry.inquiryStatus.eq(closed));
+            predicate1.and(inquiry.inquiryStatus.eq(closed));
+            predicate2.and(inquiry.inquiryStatus.eq(closed));
+        } else if (closed.equals(InquiryStatus.closed)) {
+            predicate.and(inquiry.inquiryStatus.eq(closed));
+            predicate1.and(inquiry.inquiryStatus.eq(closed));
+            predicate2.and(inquiry.inquiryStatus.eq(closed));
+        }
+
+        predicate1.and(inquiry.strategy.statusCode.eq(StrategyStatusCode.PUBLIC.getCode()));
+        predicate2.and(inquiry.strategy.statusCode.eq(StrategyStatusCode.PUBLIC.getCode()).not());
+
+        predicate.and(inquiry.id.gt(inquiryId));
+
+        // 정렬순 별
+        if (sort.equals("registrationDate")) {
+            return Optional.ofNullable(jpaQueryFactory
+                    .selectFrom(inquiry)
+                    .where(predicate)
+                    .orderBy(inquiry.id.asc())
+                    .fetchFirst());
+        } else if (sort.equals("strategyName")) {
+
+            List<Inquiry> content = new ArrayList<>();
+            List<Inquiry> results1 = jpaQueryFactory1
+                    .selectFrom(inquiry)
+                    .where(predicate1)
+                    .orderBy(inquiry.strategy.name.desc(), inquiry.id.asc()) // 따로 해서 최적화 가능
+                    .fetch();
+            List<Inquiry> results2 = jpaQueryFactory2
+                    .selectFrom(inquiry)
+                    .where(predicate2)
+                    .orderBy(inquiry.id.asc()) // 따로 해서 최적화 가능
+                    .fetch();
+
+            content.addAll(results1);
+            content.addAll(results2);
+
+            if (content.isEmpty()) {
+                return Optional.empty();
+            } else {
+                return Optional.ofNullable(content.get(0));
+            }
+        } else {
+            throw new IllegalArgumentException("정렬순을 지정하세요");
+        }
+    }
+
+    // 질문자 이전 문의 조회 최신순
+    public Optional<Inquiry> inquirerFindPreviousInquiryRegistrationDate(InquiryDetailTraderInquirerShowDto inquiryDetailTraderInquirerShowDto) {
+
+        BooleanBuilder predicate = new BooleanBuilder();
+
+        Long inquiryId = inquiryDetailTraderInquirerShowDto.getInquiryId();
+        Long inquirerId = inquiryDetailTraderInquirerShowDto.getInquirerId();
+        InquiryStatus closed = inquiryDetailTraderInquirerShowDto.getClosed();
+
+        // 질문자 별
+        if (inquirerId != null) {
+            predicate.and(inquiry.inquirer.id.eq(inquirerId));
+        }
+
+        // 전체, 답변 대기, 답변 완료
+        if (closed.equals(InquiryStatus.unclosed)) {
+            predicate.and(inquiry.inquiryStatus.eq(closed));
+        } else if (closed.equals(InquiryStatus.closed)) {
+            predicate.and(inquiry.inquiryStatus.eq(closed));
+        }
+
+        predicate.and(inquiry.id.lt(inquiryId));
+
+        return Optional.ofNullable(jpaQueryFactory
+                .selectFrom(inquiry)
+                .where(predicate)
+                .orderBy(inquiry.id.desc())
+                .fetchFirst());
+    }
+
+    // 질문자 이전 문의 조회 전략명순
+    public Optional<Inquiry> inquirerFindPreviousInquiryStrategyName(InquiryDetailTraderInquirerShowDto inquiryDetailTraderInquirerShowDto) {
+
+        BooleanBuilder predicate1 = new BooleanBuilder();
+        BooleanBuilder predicate2 = new BooleanBuilder();
+
+        Long inquiryId = inquiryDetailTraderInquirerShowDto.getInquiryId();
+        Long inquirerId = inquiryDetailTraderInquirerShowDto.getInquirerId();
+        InquiryStatus closed = inquiryDetailTraderInquirerShowDto.getClosed();
+
+        // 질문자 별
+        if (inquirerId != null) {
+            predicate1.and(inquiry.inquirer.id.eq(inquirerId));
+            predicate2.and(inquiry.inquirer.id.eq(inquirerId));
+        }
+
+        // 전체, 답변 대기, 답변 완료
+        if (closed.equals(InquiryStatus.unclosed)) {
+            predicate1.and(inquiry.inquiryStatus.eq(closed));
+            predicate2.and(inquiry.inquiryStatus.eq(closed));
+        } else if (closed.equals(InquiryStatus.closed)) {
+            predicate1.and(inquiry.inquiryStatus.eq(closed));
+            predicate2.and(inquiry.inquiryStatus.eq(closed));
+        }
+
+        predicate1.and(inquiry.strategy.statusCode.eq(StrategyStatusCode.PUBLIC.getCode()));
+        predicate2.and(inquiry.strategy.statusCode.eq(StrategyStatusCode.PUBLIC.getCode()).not());
+
+        List<Inquiry> content = new ArrayList<>();
+        List<Inquiry> results1 = jpaQueryFactory1
+                .selectFrom(inquiry)
+                .where(predicate1)
+                .orderBy(inquiry.strategy.name.asc(), inquiry.id.desc()) // 따로 해서 최적화 가능
+                .fetch();
+        List<Inquiry> results2 = jpaQueryFactory2
+                .selectFrom(inquiry)
+                .where(predicate2)
+                .orderBy(inquiry.id.desc()) // 따로 해서 최적화 가능
+                .fetch();
+
+        content.addAll(results1);
+        content.addAll(results2);
+
+        if (content.isEmpty()) {
+            return Optional.empty();
+        } else {
+
+            for (int i = 0; i < content.size(); i++) {
+                if (content.get(i).getId().equals(inquiryId)) {
+                    if (i == content.size() - 1) {
+                        return Optional.empty();
+                    } else {
+                        return Optional.ofNullable(content.get(i+1));
+                    }
+                }
+            }
+
+            return Optional.empty();
+        }
+    }
+
+    // 질문자 다음 문의 조회 최신순
+    public Optional<Inquiry> inquirerFindNextInquiryRegistrationDate(InquiryDetailTraderInquirerShowDto inquiryDetailTraderInquirerShowDto) {
+
+        BooleanBuilder predicate = new BooleanBuilder();
+
+        Long inquiryId = inquiryDetailTraderInquirerShowDto.getInquiryId();
+        Long inquirerId = inquiryDetailTraderInquirerShowDto.getInquirerId();
+        InquiryStatus closed = inquiryDetailTraderInquirerShowDto.getClosed();
+
+        // 질문자 별
+        if (inquirerId != null) {
+            predicate.and(inquiry.inquirer.id.eq(inquirerId));
+        }
+
+        // 전체, 답변 대기, 답변 완료
+        if (closed.equals(InquiryStatus.unclosed)) {
+            predicate.and(inquiry.inquiryStatus.eq(closed));
+        } else if (closed.equals(InquiryStatus.closed)) {
+            predicate.and(inquiry.inquiryStatus.eq(closed));
+        }
+
+        predicate.and(inquiry.id.gt(inquiryId));
+
+        return Optional.ofNullable(jpaQueryFactory
+                .selectFrom(inquiry)
+                .where(predicate)
+                .orderBy(inquiry.id.asc())
+                .fetchFirst());
+    }
+
+    // 질문자 다음 문의 조회 전략명순
+    public Optional<Inquiry> inquirerFindNextInquiryStrategyName(InquiryDetailTraderInquirerShowDto inquiryDetailTraderInquirerShowDto) {
+
+        BooleanBuilder predicate1 = new BooleanBuilder();
+        BooleanBuilder predicate2 = new BooleanBuilder();
+
+        Long inquiryId = inquiryDetailTraderInquirerShowDto.getInquiryId();
+        Long inquirerId = inquiryDetailTraderInquirerShowDto.getInquirerId();
+        InquiryStatus closed = inquiryDetailTraderInquirerShowDto.getClosed();
+
+        // 질문자 별
+        if (inquirerId != null) {
+            predicate1.and(inquiry.inquirer.id.eq(inquirerId));
+            predicate2.and(inquiry.inquirer.id.eq(inquirerId));
+        }
+
+        // 전체, 답변 대기, 답변 완료
+        if (closed.equals(InquiryStatus.unclosed)) {
+            predicate1.and(inquiry.inquiryStatus.eq(closed));
+            predicate2.and(inquiry.inquiryStatus.eq(closed));
+        } else if (closed.equals(InquiryStatus.closed)) {
+            predicate1.and(inquiry.inquiryStatus.eq(closed));
+            predicate2.and(inquiry.inquiryStatus.eq(closed));
+        }
+
+        predicate1.and(inquiry.strategy.statusCode.eq(StrategyStatusCode.PUBLIC.getCode()));
+        predicate2.and(inquiry.strategy.statusCode.eq(StrategyStatusCode.PUBLIC.getCode()).not());
+
+        List<Inquiry> content = new ArrayList<>();
+        List<Inquiry> results1 = jpaQueryFactory1
+                .selectFrom(inquiry)
+                .where(predicate1)
+                .orderBy(inquiry.strategy.name.asc(), inquiry.id.desc()) // 따로 해서 최적화 가능
+                .fetch();
+        List<Inquiry> results2 = jpaQueryFactory2
+                .selectFrom(inquiry)
+                .where(predicate2)
+                .orderBy(inquiry.id.desc()) // 따로 해서 최적화 가능
+                .fetch();
+
+        content.addAll(results1);
+        content.addAll(results2);
+
+        if (content.isEmpty()) {
+            return Optional.empty();
+        } else {
+
+            for (int i = 0; i < content.size(); i++) {
+                if (content.get(i).getId().equals(inquiryId)) {
+                    if (i == 0) {
+                        return Optional.empty();
+                    } else {
+                        return Optional.ofNullable(content.get(i-1));
+                    }
+                }
+            }
+
+            return Optional.empty();
+        }
+    }
+
+    // 트레이더 이전 문의 조회 최신순
+    public Optional<Inquiry> traderFindPreviousInquiryRegistrationDate(InquiryDetailTraderInquirerShowDto inquiryDetailTraderInquirerShowDto) {
+
+        BooleanBuilder predicate = new BooleanBuilder();
+
+        Long inquiryId = inquiryDetailTraderInquirerShowDto.getInquiryId();
+        Long traderId = inquiryDetailTraderInquirerShowDto.getTraderId();
+        InquiryStatus closed = inquiryDetailTraderInquirerShowDto.getClosed();
+
+        // 트레이더 별
+        if (traderId != null) {
+            predicate.and(inquiry.traderId.eq(traderId));
+        }
+
+        // 전체, 답변 대기, 답변 완료
+        if (closed.equals(InquiryStatus.unclosed)) {
+            predicate.and(inquiry.inquiryStatus.eq(closed));
+        } else if (closed.equals(InquiryStatus.closed)) {
+            predicate.and(inquiry.inquiryStatus.eq(closed));
+        }
+
+        predicate.and(inquiry.id.lt(inquiryId));
+
+        return Optional.ofNullable(jpaQueryFactory
+                .selectFrom(inquiry)
+                .where(predicate)
+                .orderBy(inquiry.id.desc())
+                .fetchFirst());
+    }
+
+    // 트레이더 이전 문의 조회 전략명순
+    public Optional<Inquiry> traderFindPreviousInquiryStrategyName(InquiryDetailTraderInquirerShowDto inquiryDetailTraderInquirerShowDto) {
+
+        BooleanBuilder predicate1 = new BooleanBuilder();
+        BooleanBuilder predicate2 = new BooleanBuilder();
+
+        Long inquiryId = inquiryDetailTraderInquirerShowDto.getInquiryId();
+        Long traderId = inquiryDetailTraderInquirerShowDto.getTraderId();
+        InquiryStatus closed = inquiryDetailTraderInquirerShowDto.getClosed();
+        String sort = inquiryDetailTraderInquirerShowDto.getSort();
+
+        // 트레이더 별
+        if (traderId != null) {
+            predicate1.and(inquiry.traderId.eq(traderId));
+            predicate2.and(inquiry.traderId.eq(traderId));
+        }
+
+        // 전체, 답변 대기, 답변 완료
+        if (closed.equals(InquiryStatus.unclosed)) {
+            predicate1.and(inquiry.inquiryStatus.eq(closed));
+            predicate2.and(inquiry.inquiryStatus.eq(closed));
+        } else if (closed.equals(InquiryStatus.closed)) {
+            predicate1.and(inquiry.inquiryStatus.eq(closed));
+            predicate2.and(inquiry.inquiryStatus.eq(closed));
+        }
+
+        predicate1.and(inquiry.strategy.statusCode.eq(StrategyStatusCode.NOT_USING_STATE.getCode()).not());
+        predicate2.and(inquiry.strategy.statusCode.eq(StrategyStatusCode.NOT_USING_STATE.getCode()));
+
+        List<Inquiry> content = new ArrayList<>();
+        List<Inquiry> results1 = jpaQueryFactory1
+                .selectFrom(inquiry)
+                .where(predicate1)
+                .orderBy(inquiry.strategy.name.asc(), inquiry.id.desc()) // 따로 해서 최적화 가능
+                .fetch();
+        List<Inquiry> results2 = jpaQueryFactory2
+                .selectFrom(inquiry)
+                .where(predicate2)
+                .orderBy(inquiry.id.desc()) // 따로 해서 최적화 가능
+                .fetch();
+
+        content.addAll(results1);
+        content.addAll(results2);
+
+        if (content.isEmpty()) {
+            return Optional.empty();
+        } else {
+
+            for (int i = 0; i < content.size(); i++) {
+                if (content.get(i).getId().equals(inquiryId)) {
+                    if (i == content.size() - 1) {
+                        return Optional.empty();
+                    } else {
+                        return Optional.ofNullable(content.get(i+1));
+                    }
+                }
+            }
+
+            return Optional.empty();
+        }
+    }
+
+    // 트레이더 다음 문의 조회 최신순
+    public Optional<Inquiry> traderFindNextInquiryRegistrationDate(InquiryDetailTraderInquirerShowDto inquiryDetailTraderInquirerShowDto) {
+
+        BooleanBuilder predicate = new BooleanBuilder();
+
+        Long inquiryId = inquiryDetailTraderInquirerShowDto.getInquiryId();
+        Long traderId = inquiryDetailTraderInquirerShowDto.getTraderId();
+        InquiryStatus closed = inquiryDetailTraderInquirerShowDto.getClosed();
+
+        // 트레이더 별
+        if (traderId != null) {
+            predicate.and(inquiry.traderId.eq(traderId));
+        }
+
+        // 전체, 답변 대기, 답변 완료
+        if (closed.equals(InquiryStatus.unclosed)) {
+            predicate.and(inquiry.inquiryStatus.eq(closed));
+        } else if (closed.equals(InquiryStatus.closed)) {
+            predicate.and(inquiry.inquiryStatus.eq(closed));
+        }
+
+        predicate.and(inquiry.id.gt(inquiryId));
+
+        return Optional.ofNullable(jpaQueryFactory
+                .selectFrom(inquiry)
+                .where(predicate)
+                .orderBy(inquiry.id.asc())
+                .fetchFirst());
+    }
+
+    // 트레이더 다음 문의 조회 전략명순
+    public Optional<Inquiry> traderFindNextInquiryStrategyName(InquiryDetailTraderInquirerShowDto inquiryDetailTraderInquirerShowDto) {
+
+        BooleanBuilder predicate1 = new BooleanBuilder();
+        BooleanBuilder predicate2 = new BooleanBuilder();
+
+        Long inquiryId = inquiryDetailTraderInquirerShowDto.getInquiryId();
+        Long traderId = inquiryDetailTraderInquirerShowDto.getTraderId();
+        InquiryStatus closed = inquiryDetailTraderInquirerShowDto.getClosed();
+        String sort = inquiryDetailTraderInquirerShowDto.getSort();
+
+        // 트레이더 별
+        if (traderId != null) {
+            predicate1.and(inquiry.traderId.eq(traderId));
+            predicate2.and(inquiry.traderId.eq(traderId));
+        }
+
+        // 전체, 답변 대기, 답변 완료
+        if (closed.equals(InquiryStatus.unclosed)) {
+            predicate1.and(inquiry.inquiryStatus.eq(closed));
+            predicate2.and(inquiry.inquiryStatus.eq(closed));
+        } else if (closed.equals(InquiryStatus.closed)) {
+            predicate1.and(inquiry.inquiryStatus.eq(closed));
+            predicate2.and(inquiry.inquiryStatus.eq(closed));
+        }
+
+        predicate1.and(inquiry.strategy.statusCode.eq(StrategyStatusCode.NOT_USING_STATE.getCode()).not());
+        predicate2.and(inquiry.strategy.statusCode.eq(StrategyStatusCode.NOT_USING_STATE.getCode()));
+
+        List<Inquiry> content = new ArrayList<>();
+        List<Inquiry> results1 = jpaQueryFactory1
+                .selectFrom(inquiry)
+                .where(predicate1)
+                .orderBy(inquiry.strategy.name.asc(), inquiry.id.desc()) // 따로 해서 최적화 가능
+                .fetch();
+        List<Inquiry> results2 = jpaQueryFactory2
+                .selectFrom(inquiry)
+                .where(predicate2)
+                .orderBy(inquiry.id.desc()) // 따로 해서 최적화 가능
+                .fetch();
+
+        content.addAll(results1);
+        content.addAll(results2);
+
+        if (content.isEmpty()) {
+            return Optional.empty();
+        } else {
+
+            for (int i = 0; i < content.size(); i++) {
+                if (content.get(i).getId().equals(inquiryId)) {
+                    if (i == 0) {
+                        return Optional.empty();
+                    } else {
+                        return Optional.ofNullable(content.get(i-1));
+                    }
+                }
+            }
+
+            return Optional.empty();
+        }
     }
 }

--- a/src/main/java/com/be3c/sysmetic/domain/member/repository/NoticeRepository.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/repository/NoticeRepository.java
@@ -30,21 +30,21 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> , NoticeRe
     // 제목으로 찾기
     List<Notice> findByNoticeTitle(String noticeTitle);
 
-    // 관리자 이전 문의 조회
-    @Query("select n from Notice n where n.id < :noticeId order by n.id desc")
-    List<Notice> findPreviousNoticeAdmin(@Param("noticeId") Long noticeId, Pageable pageable);
-
-    // 관리자 다음 문의 조회
-    @Query("select n from Notice n where n.id > :noticeId order by n.id asc")
-    List<Notice> findNextNoticeAdmin(@Param("noticeId") Long noticeId, Pageable pageable);
-
-    // 일반 이전 문의 조회
-    @Query("select n from Notice n where n.id < :noticeId and n.isOpen = true order by n.id desc")
-    List<Notice> findPreviousNotice(@Param("noticeId") Long noticeId, Pageable pageable);
-
-    // 일반 다음 문의 조회
-    @Query("select n from Notice n where n.id > :noticeId and n.isOpen = true order by n.id asc")
-    List<Notice> findNextNotice(@Param("noticeId") Long noticeId, Pageable pageable);
+//    // 관리자 이전 문의 조회
+//    @Query("select n from Notice n where n.id < :noticeId order by n.id desc")
+//    List<Notice> findPreviousNoticeAdmin(@Param("noticeId") Long noticeId, Pageable pageable);
+//
+//    // 관리자 다음 문의 조회
+//    @Query("select n from Notice n where n.id > :noticeId order by n.id asc")
+//    List<Notice> findNextNoticeAdmin(@Param("noticeId") Long noticeId, Pageable pageable);
+//
+//    // 일반 이전 문의 조회
+//    @Query("select n from Notice n where n.id < :noticeId and n.isOpen = true order by n.id desc")
+//    List<Notice> findPreviousNotice(@Param("noticeId") Long noticeId, Pageable pageable);
+//
+//    // 일반 다음 문의 조회
+//    @Query("select n from Notice n where n.id > :noticeId and n.isOpen = true order by n.id asc")
+//    List<Notice> findNextNotice(@Param("noticeId") Long noticeId, Pageable pageable);
 
     @Query("SELECT new com.be3c.sysmetic.global.util.admin.dto.AdminNoticeResponseDto(" +
             "n.id, n.noticeTitle, n.createdAt) FROM Notice n")

--- a/src/main/java/com/be3c/sysmetic/domain/member/repository/NoticeRepositoryCustom.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/repository/NoticeRepositoryCustom.java
@@ -4,9 +4,19 @@ import com.be3c.sysmetic.domain.member.entity.Notice;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Optional;
+
 public interface NoticeRepositoryCustom {
 
     Page<Notice> adminNoticeSearchWithBooleanBuilder(String searchType, String searchText, Pageable pageable);
 
     Page<Notice> noticeSearchWithBooleanBuilder(String searchText, Pageable pageable);
+
+    Optional<Notice> findPreviousNoticeAdmin(Long noticeId, String SearchType, String SearchText);
+
+    Optional<Notice> findNextNoticeAdmin(Long noticeId, String SearchType, String SearchText);
+
+    Optional<Notice> findPreviousNotice(Long noticeId, String SearchText);
+
+    Optional<Notice> findNextNotice(Long noticeId, String SearchText);
 }

--- a/src/main/java/com/be3c/sysmetic/domain/member/service/InquiryService.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/service/InquiryService.java
@@ -40,15 +40,17 @@ public interface InquiryService {
 
     InquiryAdminListOneShowResponseDto inquiryToInquiryAdminOneResponseDto(Inquiry inquiry);
 
-    InquiryAnswerAdminShowResponseDto inquiryIdToInquiryAnswerAdminShowResponseDto (Long inquiryId);
+    InquiryAnswerAdminShowResponseDto inquiryIdToInquiryAnswerAdminShowResponseDto (InquiryDetailAdminShowDto inquiryDetailAdminShowDto);
 
-    InquiryListOneShowResponseDto inquiryToInquiryOneResponseDto(Inquiry inquiry);
+    InquiryListOneShowResponseDto InquiryToInquiryInquirerOneResponseDto(Inquiry inquiry);
+
+    InquiryListOneShowResponseDto inquiryToInquirytraderOneResponseDto(Inquiry inquiry);
 
     InquirySavePageShowResponseDto strategyToInquirySavePageShowResponseDto(Strategy strategy);
 
-    InquiryAnswerInquirerShowResponseDto inquiryIdToInquiryAnswerInquirerShowResponseDto(Long inquiryId);
+    InquiryAnswerInquirerShowResponseDto inquiryIdToInquiryAnswerInquirerShowResponseDto(InquiryDetailTraderInquirerShowDto inquiryDetailTraderInquirerShowDto);
 
-    InquiryAnswerTraderShowResponseDto inquiryIdToInquiryAnswerTraderShowResponseDto(Long inquiryId);
+    InquiryAnswerTraderShowResponseDto inquiryIdToInquiryAnswerTraderShowResponseDto(InquiryDetailTraderInquirerShowDto inquiryDetailTraderInquirerShowDto);
 
     // 문의자 검색 조회
     // 정렬 순 셀렉트 박스 (최신순, 전략명)

--- a/src/main/java/com/be3c/sysmetic/domain/member/service/NoticeService.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/service/NoticeService.java
@@ -43,9 +43,9 @@ public interface NoticeService {
 
     NoticeAdminListOneShowResponseDto noticeToNoticeAdminListOneShowResponseDto(Notice notice);
 
-    NoticeDetailAdminShowResponseDto noticeIdToNoticeDetailAdminShowResponseDto(Long noticeId);
+    NoticeDetailAdminShowResponseDto noticeIdToNoticeDetailAdminShowResponseDto(Long noticeId, String searchType, String searchText);
 
-    NoticeDetailShowResponseDto noticeIdToticeDetailShowResponseDto(Long noticeId);
+    NoticeDetailShowResponseDto noticeIdToticeDetailShowResponseDto(Long noticeId, String searchText);
 
     NoticeShowModifyPageResponseDto noticeIdTonoticeShowModifyPageResponseDto(Long noticeId);
 }

--- a/src/main/java/com/be3c/sysmetic/domain/member/service/NoticeServiceImpl.java
+++ b/src/main/java/com/be3c/sysmetic/domain/member/service/NoticeServiceImpl.java
@@ -11,6 +11,7 @@ import com.be3c.sysmetic.global.util.file.dto.FileWithInfoResponse;
 import com.be3c.sysmetic.global.util.file.service.FileService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.apache.poi.sl.draw.geom.GuideIf;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -326,38 +327,36 @@ public class NoticeServiceImpl implements NoticeService {
     }
 
     @Override
-    public NoticeDetailAdminShowResponseDto noticeIdToNoticeDetailAdminShowResponseDto(Long noticeId) {
+    public NoticeDetailAdminShowResponseDto noticeIdToNoticeDetailAdminShowResponseDto(Long noticeId, String searchType, String searchText) {
 
         Notice notice = noticeRepository.findById(noticeId).orElseThrow(() -> new EntityNotFoundException("공지사항이 없습니다."));
 
-        List<Notice> previousNoticeList = noticeRepository.findPreviousNoticeAdmin(noticeId, PageRequest.of(0, 1));
+        Optional<Notice> previousNoticeOptional = noticeRepository.findPreviousNoticeAdmin(noticeId, searchType, searchText);
         Long previousNoticeId;
         String previousNoticeTitle;
         LocalDateTime previousNoticeWriteDate;
-        if (previousNoticeList.isEmpty()) {
+        if (previousNoticeOptional.isEmpty()) {
             previousNoticeId = null;
             previousNoticeTitle = null;
             previousNoticeWriteDate = null;
         } else {
-            Notice previousNotice = previousNoticeList.get(0);
-            previousNoticeId = previousNotice.getId();
-            previousNoticeTitle = previousNotice.getNoticeTitle();
-            previousNoticeWriteDate = previousNotice.getWriteDate();
+            previousNoticeId = previousNoticeOptional.orElse(null).getId();
+            previousNoticeTitle = previousNoticeOptional.orElse(null).getNoticeTitle();
+            previousNoticeWriteDate = previousNoticeOptional.orElse(null).getWriteDate();
         }
 
-        List<Notice> nextNoticeList = noticeRepository.findNextNoticeAdmin(noticeId, PageRequest.of(0, 1));
+        Optional<Notice> nextNoticeOptional = noticeRepository.findNextNoticeAdmin(noticeId, searchType, searchText);
         Long nextNoticeId;
         String nextNoticeTitle;
         LocalDateTime nextNoticeWriteDate;
-        if (nextNoticeList.isEmpty()) {
+        if (nextNoticeOptional.isEmpty()) {
             nextNoticeId = null;
             nextNoticeTitle = null;
             nextNoticeWriteDate = null;
         } else {
-            Notice nextNotice = nextNoticeList.get(0);
-            nextNoticeId = nextNotice.getId();
-            nextNoticeTitle = nextNotice.getNoticeTitle();
-            nextNoticeWriteDate = nextNotice.getWriteDate();
+            nextNoticeId = nextNoticeOptional.orElse(null).getId();
+            nextNoticeTitle = nextNoticeOptional.orElse(null).getNoticeTitle();
+            nextNoticeWriteDate = nextNoticeOptional.orElse(null).getWriteDate();
         }
 
         List<NoticeDetailFileShowResponseDto> fileDtoList = null;
@@ -391,6 +390,8 @@ public class NoticeServiceImpl implements NoticeService {
         }
 
         return NoticeDetailAdminShowResponseDto.builder()
+                .searchType(searchType)
+                .searchText(searchText)
                 .noticeId(notice.getId())
                 .noticeTitle(notice.getNoticeTitle())
                 .noticeContent(notice.getNoticeContent())
@@ -413,38 +414,36 @@ public class NoticeServiceImpl implements NoticeService {
     }
 
     @Override
-    public NoticeDetailShowResponseDto noticeIdToticeDetailShowResponseDto(Long noticeId) {
+    public NoticeDetailShowResponseDto noticeIdToticeDetailShowResponseDto(Long noticeId, String searchText) {
 
         Notice notice = noticeRepository.findByIdAndAndIsOpen(noticeId).orElseThrow(() -> new EntityNotFoundException("공지사항이 없습니다."));
 
-        List<Notice> previousNoticeList = noticeRepository.findPreviousNotice(noticeId, PageRequest.of(0, 1));
+        Optional<Notice> previousNoticeOptional = noticeRepository.findPreviousNotice(noticeId, searchText);
         Long previousNoticeId;
         String previousNoticeTitle;
         LocalDateTime previousNoticeWriteDate;
-        if (previousNoticeList.isEmpty()) {
+        if (previousNoticeOptional.isEmpty()) {
             previousNoticeId = null;
             previousNoticeTitle = null;
             previousNoticeWriteDate = null;
         } else {
-            Notice previousNotice = previousNoticeList.get(0);
-            previousNoticeId = previousNotice.getId();
-            previousNoticeTitle = previousNotice.getNoticeTitle();
-            previousNoticeWriteDate = previousNotice.getWriteDate();
+            previousNoticeId = previousNoticeOptional.orElse(null).getId();
+            previousNoticeTitle = previousNoticeOptional.orElse(null).getNoticeTitle();
+            previousNoticeWriteDate = previousNoticeOptional.orElse(null).getWriteDate();
         }
 
-        List<Notice> nextNoticeList = noticeRepository.findNextNotice(noticeId, PageRequest.of(0, 1));
+        Optional<Notice> nextNoticeOptional = noticeRepository.findNextNotice(noticeId, searchText);
         Long nextNoticeId;
         String nextNoticeTitle;
         LocalDateTime nextNoticeWriteDate;
-        if (nextNoticeList.isEmpty()) {
+        if (nextNoticeOptional.isEmpty()) {
             nextNoticeId = null;
             nextNoticeTitle = null;
             nextNoticeWriteDate = null;
         } else {
-            Notice nextNotice = nextNoticeList.get(0);
-            nextNoticeId = nextNotice.getId();
-            nextNoticeTitle = nextNotice.getNoticeTitle();
-            nextNoticeWriteDate = nextNotice.getWriteDate();
+            nextNoticeId = nextNoticeOptional.orElse(null).getId();
+            nextNoticeTitle = nextNoticeOptional.orElse(null).getNoticeTitle();
+            nextNoticeWriteDate = nextNoticeOptional.orElse(null).getWriteDate();
         }
 
         List<NoticeDetailFileShowResponseDto> fileDtoList = null;
@@ -478,6 +477,7 @@ public class NoticeServiceImpl implements NoticeService {
         }
 
         return NoticeDetailShowResponseDto.builder()
+                .searchText(searchText)
                 .noticeId(notice.getId())
                 .noticeTitle(notice.getNoticeTitle())
                 .noticeContent(notice.getNoticeContent())

--- a/src/main/java/com/be3c/sysmetic/global/util/file/service/FileServiceImpl.java
+++ b/src/main/java/com/be3c/sysmetic/global/util/file/service/FileServiceImpl.java
@@ -317,6 +317,7 @@ public class FileServiceImpl implements FileService {
                 fileRepository.delete(file);
                 s3Service.deleteObject(file.getPath());
             }
+            fileRepository.flush();
         } catch (Exception e) {
             log.error("파일 삭제 실패. 파일 참조 정보: {}", fileRequest, e);
             fileRepository.saveAll(files);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,14 +1,12 @@
 spring.application.name=sysmetic
 
 # JPA Setting
-#spring.jpa.hibernate.ddl-auto=create
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.generate-ddl=false
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
-#spring.config.import=classpath:application-test.properties, cloud.properties, jwt.properties
 spring.config.import=classpath:database.properties, cloud.properties, jwt.properties
 
 spring.servlet.multipart.max-file-size=5MB

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,12 +1,14 @@
 spring.application.name=sysmetic
 
 # JPA Setting
+#spring.jpa.hibernate.ddl-auto=create
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.generate-ddl=false
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
+#spring.config.import=classpath:application-test.properties, cloud.properties, jwt.properties
 spring.config.import=classpath:database.properties, cloud.properties, jwt.properties
 
 spring.servlet.multipart.max-file-size=5MB

--- a/src/test/java/com/be3c/sysmetic/domain/member/service/InquiryServiceTest.java
+++ b/src/test/java/com/be3c/sysmetic/domain/member/service/InquiryServiceTest.java
@@ -43,20 +43,21 @@ public class InquiryServiceTest {
     @Autowired
     private InquiryAnswerRepository inquiryAnswerRepository;
 
-//    @Test
-////    @Rollback(value = false)
-//    public void dummy_data() throws Exception {
-////        Member member1 = createMember("일반닉네임1");
-////        Member member2 = createMember("일반닉네임2");
-////        Member member3 = createMember("일반닉네임3");
-////        Member member4 = createMember("일반닉네임4");
-//        Member member1 = createMember("테스트1"); // user
-//        Member member2 = createMember("테스트2"); // trader
-//        Member member3 = createMember("테스트3"); // user manager
-//        Member member4 = createMember("테스트4"); // trader manager
-//        Member member6 = createMember("테스트");
-//        Member member7 = createMember("테스트");
-//        Member member8 = createMember("테스트");
+    @Test
+    @Rollback(value = false)
+    public void dummy_data() throws Exception {
+//        Member member1 = createMember("일반닉네임1");
+//        Member member2 = createMember("일반닉네임2");
+//        Member member3 = createMember("일반닉네임3");
+//        Member member4 = createMember("일반닉네임4");
+        Member member1 = createMember("테스트1"); // user
+        Member member2 = createMember("테스트2"); // trader
+        Member member3 = createMember("테스트3"); // user manager
+        Member member4 = createMember("테스트4"); // trader manager
+        Member member5 = createMember("테스트5"); // trader manager
+        Member member6 = createMember("테스트");
+        Member member7 = createMember("테스트");
+        Member member8 = createMember("테스트");
 //        Member member9 = createMember("테스트");
 //        Member member10 = createMember("테스트");
 //        Member member11 = createMember("테스트");
@@ -64,80 +65,83 @@ public class InquiryServiceTest {
 //        Member member13 = createMember("테스트");
 //        Member member14 = createMember("테스트");
 //        Member member15 = createMember("테스트");
-//
+
 //        for (int i = 1; i < 124; i++) {
 //            createStrategyWithMember("빈 전략", StrategyStatusCode.PUBLIC.getCode(), member2);
 //        }
-//        Strategy strategy1 = createStrategyWithMember("삼성전자", StrategyStatusCode.PUBLIC.getCode(), member11);
-//        Strategy strategy2 = createStrategyWithMember("LG전자", StrategyStatusCode.PUBLIC.getCode(), member12);
-//        Strategy strategy3 = createStrategyWithMember("애플", StrategyStatusCode.NOT_USING_STATE.getCode(), member13);
-//        Strategy strategy4 = createStrategyWithMember("테슬라", StrategyStatusCode.REQUEST.getCode(), member14);
-////
-////        for (int i = 1; i < 204; i++) {
-////            Inquiry preInquiry = Inquiry.builder()
-////                    .strategy(strategy1)
-////                    .inquirer(member5)
-////                    .traderId(strategy1.getTrader().getId())
-////                    .inquiryStatus(InquiryStatus.closed)
-////                    .inquiryTitle("문의제목")
-////                    .inquiryContent("문의내용")
-////                    .inquiryRegistrationDate(LocalDateTime.now())
-////                    .build();
-////            inquiryRepository.save(preInquiry);
-////            if (i < 102) {
-////                InquiryAnswer inquiryAnswer = InquiryAnswer.builder()
-////                        .inquiry(preInquiry)
-////                        .answerTitle("답변제목")
-////                        .answerContent("답변내용")
-////                        .answerRegistrationDate(LocalDateTime.now())
-////                        .build();
-////                inquiryAnswerRepository.save(inquiryAnswer);
-////            }
-////        }
+        Strategy strategy1 = createStrategyWithMember("삼성전자", StrategyStatusCode.PUBLIC.getCode(), member7);
+        Strategy strategy2 = createStrategyWithMember("LG전자", StrategyStatusCode.PUBLIC.getCode(), member6);
+        Strategy strategy3 = createStrategyWithMember("애플", StrategyStatusCode.PUBLIC.getCode(), member8);
+        Strategy strategy4 = createStrategyWithMember("테슬라", StrategyStatusCode.PRIVATE.getCode(), member7);
 //
-//        int countInquiry = 1;
-////        int countInquiryAnswer = 1;
-//        Strategy strategy = null;
-//        Member member = null;
-//        InquiryStatus inquiryStatus = null;
-//        for(int i = 1; i <= 4; i++) {
-//            if (i == 1) { strategy = strategy1; }
-//            else if (i == 2) { strategy = strategy2; }
-//            else if (i == 3) { strategy = strategy3; }
-//            else if (i == 4) { strategy = strategy4; }
-//            for(int j = 1; j <= 3; j=j+2) {
-//                if (j == 1) { member = member1; }
-//                else if (j == 3) { member = member3; }
-//                for(int k = 1; k <= 2; k++) {
-//                    if (k == 1) { inquiryStatus = InquiryStatus.closed; }
-//                    if (k == 2) { inquiryStatus = InquiryStatus.unclosed; }
-//                    for(int l = 1; l <= 10; l++) {
-//                        Inquiry inquiry = Inquiry.builder()
-//                                .strategy(strategy)
-//                                .inquirer(member)
-//                                .traderId(strategy.getTrader().getId())
-//                                .inquiryStatus(inquiryStatus)
-//                                .inquiryTitle("문의제목" + countInquiry)
-//                                .inquiryContent("문의내용" + countInquiry)
-//                                .inquiryRegistrationDate(LocalDateTime.now())
-//                                .build();
-//                        inquiryRepository.save(inquiry);
-//                        if (inquiryStatus == InquiryStatus.closed) {
-//                            InquiryAnswer inquiryAnswer = InquiryAnswer.builder()
-//                                    .inquiry(inquiry)
-//                                    .answerTitle("답변제목" + countInquiry)
-//                                    .answerContent("답변내용" + countInquiry)
-//                                    .answerRegistrationDate(LocalDateTime.now())
-//                                    .build();
-//                            inquiryAnswerRepository.save(inquiryAnswer);
-////                            countInquiryAnswer++;
-//                        }
-//                        countInquiry++;
-//                    }
-//                }
+//        for (int i = 1; i < 204; i++) {
+//            Inquiry preInquiry = Inquiry.builder()
+//                    .strategy(strategy1)
+//                    .inquirer(member5)
+//                    .traderId(strategy1.getTrader().getId())
+//                    .inquiryStatus(InquiryStatus.closed)
+//                    .inquiryTitle("문의제목")
+//                    .inquiryContent("문의내용")
+//                    .inquiryRegistrationDate(LocalDateTime.now())
+//                    .build();
+//            inquiryRepository.save(preInquiry);
+//            if (i < 102) {
+//                InquiryAnswer inquiryAnswer = InquiryAnswer.builder()
+//                        .inquiry(preInquiry)
+//                        .answerTitle("답변제목")
+//                        .answerContent("답변내용")
+//                        .answerRegistrationDate(LocalDateTime.now())
+//                        .build();
+//                inquiryAnswerRepository.save(inquiryAnswer);
 //            }
 //        }
-//    }
+
+        int countInquiry = 1;
+//        int countInquiryAnswer = 1;
+        Strategy strategy = null;
+        Member member = null;
+        InquiryStatus inquiryStatus = null;
+        for(int i = 1; i <= 4; i++) {
+            if (i == 1) { strategy = strategy1; }
+            else if (i == 2) { strategy = strategy2; }
+            else if (i == 3) { strategy = strategy3; }
+            else if (i == 4) { strategy = strategy4; }
+            for(int j = 1; j <= 5; j++) {
+                if (j == 1) { member = member1; }
+                else if (j == 2) { member = member2; }
+                else if (j == 3) { member = member3; }
+                else if (j == 4) { member = member4; }
+                else if (j == 5) { member = member5; }
+                for(int k = 1; k <= 1; k++) {
+                    if (k == 1) { inquiryStatus = InquiryStatus.unclosed; }
+//                    if (k == 2) { inquiryStatus = InquiryStatus.closed; }
+                    for(int l = 1; l <= 1; l++) {
+                        Inquiry inquiry = Inquiry.builder()
+                                .strategy(strategy)
+                                .inquirer(member)
+                                .traderId(strategy.getTrader().getId())
+                                .inquiryStatus(inquiryStatus)
+                                .inquiryTitle("문의제목" + countInquiry)
+                                .inquiryContent("문의내용" + countInquiry)
+                                .inquiryRegistrationDate(LocalDateTime.now())
+                                .build();
+                        inquiryRepository.save(inquiry);
+                        if (inquiryStatus == InquiryStatus.closed) {
+                            InquiryAnswer inquiryAnswer = InquiryAnswer.builder()
+                                    .inquiry(inquiry)
+                                    .answerTitle("답변제목" + countInquiry)
+                                    .answerContent("답변내용" + countInquiry)
+                                    .answerRegistrationDate(LocalDateTime.now())
+                                    .build();
+                            inquiryAnswerRepository.save(inquiryAnswer);
+//                            countInquiryAnswer++;
+                        }
+                        countInquiry++;
+                    }
+                }
+            }
+        }
+    }
 
 
     @Test

--- a/src/test/java/com/be3c/sysmetic/domain/strategy/service/ReplyServiceTest.java
+++ b/src/test/java/com/be3c/sysmetic/domain/strategy/service/ReplyServiceTest.java
@@ -278,7 +278,6 @@ public class ReplyServiceTest {
         Reply reply = replyRepository.findAll().get(0);
 
         replyService.deleteReply(ReplyDeleteRequestDto.builder()
-                        .id(reply.getId())
                         .strategyId(strategy.getId())
                         .build()
         );


### PR DESCRIPTION
# 🚀 Pull Request

fix: 공지사항, 문의 이전 다음 글 수정

## #️⃣ 연관된 이슈

ex) #이슈번호

## 📋 작업 내용

공지사항, 문의에서 검색, 정렬한 목록에서 상세 페이지에 들어갔을 때 이전 다음 글이 전체 목록 기준으로 나오는  오류 수정